### PR TITLE
Add record to preview tab

### DIFF
--- a/flaskr/assets/scss/tables.scss
+++ b/flaskr/assets/scss/tables.scss
@@ -67,6 +67,8 @@
 
 .simple-table {
   margin-left: 40px;
+  font-size: 12px;
+  opacity: .8;
 }
 
 .simple-table td, .simple-table th {
@@ -175,11 +177,11 @@
 }
 
 .results-row > div:last-child {
-  width: 190px;
+  width: 240px;
 }
 
 .results-row > div:first-child {
-  width: 190px;
+  width: 240px;
 }
 
 .right-align {

--- a/flaskr/head_to_head.py
+++ b/flaskr/head_to_head.py
@@ -151,3 +151,67 @@ def all_time(owner_id_1, owner_id_2):
         data["current_streak"],
         data["longest_streak"]
         ]
+
+
+def record(owner_id_1, owner_id_2):
+    # Need to use owner id because some ids stayed
+    # the same through multiple owners
+    data = {
+        owner_id_1: {
+            "owner_id": owner_id_1,
+            "wins": 0,
+        },
+        owner_id_2: {
+            "owner_id": owner_id_2,
+            "wins": 0,
+        },
+    }
+
+    end_year = latest_season()
+    current_info = load_data(end_year, 'mNav')
+
+    for year in range(FIRST_SEASON, end_year + 1):
+        weeks = number_of_weeks(year, True)
+        if weeks == 0:
+            continue
+
+        matchups = load_matchups(year)
+        team_owner_mapping = load_data(year, 'mNav')["teams"]
+
+        for matchup in matchups:
+            if matchup["matchupPeriodId"] > weeks:
+                break
+
+            if is_bye_week(matchup):
+                continue
+
+            away_details = matchup["away"]
+            away_team_id = away_details["teamId"]
+            away_owner_id = next(
+                item for item in team_owner_mapping
+                if item["id"] == away_team_id
+                )["owners"][0]
+
+            home_details = matchup["home"]
+            home_team_id = home_details["teamId"]
+            home_owner_id = next(
+                item for item in team_owner_mapping
+                if item["id"] == home_team_id
+                )["owners"][0]
+
+            right_teams = compare_lists(
+                [owner_id_1, owner_id_2],
+                [away_owner_id, home_owner_id])
+            if not right_teams:
+                continue
+
+            # matchup be right
+            if matchup["playoffTierType"] == "NONE" or matchup["playoffTierType"] == "WINNERS_BRACKET":
+                if matchup["winner"] == "AWAY":
+                    data[away_owner_id]["wins"] += 1
+                elif matchup["winner"] == "HOME":
+                    data[home_owner_id]["wins"] += 1
+    return [
+        data[owner_id_1],
+        data[owner_id_2],
+        ]

--- a/flaskr/static/tables.css
+++ b/flaskr/static/tables.css
@@ -53,7 +53,9 @@
                     opacity: 1; }
 
                     .simple-table {
-                      margin-left: 40px; }
+                      margin-left: 40px;
+                      font-size: 12px;
+                      opacity: 0.8; }
 
                       .simple-table td, .simple-table th {
                         text-align: left;
@@ -141,10 +143,10 @@
                                                               margin: 10px; }
 
                                                               .results-row > div:last-child {
-                                                                width: 190px; }
+                                                                width: 240px; }
 
                                                                 .results-row > div:first-child {
-                                                                  width: 190px; }
+                                                                  width: 240px; }
 
                                                                   .right-align {
                                                                     text-align: right; }

--- a/flaskr/templates/weekly-report.html
+++ b/flaskr/templates/weekly-report.html
@@ -79,9 +79,9 @@
           <div class="results-table">
             {% for matchup in report["preview"] %}
               <div class="results-row">
-                <div class="right-align">{{ matchup["home"] }}</div>
+                <div class="right-align">{{ matchup["home"] + " (" + matchup["home_record"] + ")"}}</div>
                 <div class="center-align">vs.</div>
-                <div class="left-align">{{ matchup["away"] }}</div>
+                <div class="left-align">{{ matchup["away"] + " (" + matchup["away_record"] + ")" }}</div>
               </div>
             {% endfor %}
           </div>


### PR DESCRIPTION
Add the team's record to the weekly report preview tab. Added a head_to_head function to only return h2h record of two owners, but didn't include it yet. It takes too long to run for each matchup. Probably need to make the api calls be asynchronous or really slim down that function before using that.